### PR TITLE
Support namespaces other than Filecoin

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,20 @@ class LotusRPC {
         } else if (prop === 'then') {
           return undefined
         } else {
-          const method = prop.charAt(0).toUpperCase() + prop.slice(1)
+          let method = prop.charAt(0).toUpperCase() + prop.slice(1)
           const schemaMethod = schema.methods[method]
           if (schemaMethod) {
+            if (schemaMethod.namespace && method.startsWith(schemaMethod.namespace)) {
+              // Namespaces other than "Filecoin" are permitted such that name of the
+              // `schemaMethod` provided in the schema is `NamespaceMethod` for the respective
+              // `Namespace.Method` method. Further, the `schemaMethod` needs to provide
+              // the `namespace` string set to `Namespace`. This allows calling
+              // provider.namespaceMethod() or provider.NamespaceMethod().
+              method = `${schemaMethod.namespace}.${method.slice(schemaMethod.namespace.length)}`;
+            } else {
+              method = `Filecoin.${method}`;
+            }
+
             if (schemaMethod.subscription) {
               return this.callSchemaMethodSub.bind(this, method, schemaMethod)
             } else {
@@ -35,7 +46,7 @@ class LotusRPC {
   async callSchemaMethod (method, schemaMethod, ...args) {
     await this.provider.connect()
     const request = {
-      method: `Filecoin.${method}`
+      method
     }
     request.params = args
     return this.provider.send(request, schemaMethod)
@@ -44,7 +55,7 @@ class LotusRPC {
   callSchemaMethodSub (method, schemaMethod, ...args) {
     // await this.provider.connect()
     const request = {
-      method: `Filecoin.${method}`
+      method
     }
     const cb = args[0]
     request.params = args.slice(1)


### PR DESCRIPTION
I'm creating the [Filecoin-flavored Ganache](https://www.trufflesuite.com/blog/announcing-collaboration-with-filecoin#filecoin-flavored-ganache-simulate-filecoin-summer-fall-winter-), and we implemented some custom, specific to Ganache RPC methods to control the internals of Ganache that are not directly related to Lotus.

We didn't believe these belonged to the `Filecoin` namespace as that could confuse users when they finally moved their dapps to the testnet/mainnet and realized Lotus doesn't support these special methods; they're currently implemented with the `Ganache` namespace (e.g. the `Ganache.MineTipset` RPC method manually mines a tipset arbitrarily).

However, this breaks usage with `lotus-client-rpc` since this library hardcodes the `Filecoin.` prefix to all methods. This PR proposes some changes that allows users to provide a schema with an optional `namespace` field in the method's schema object.

For example, with this PR:

``` javascript
const schema = {
  ChainHead: {},
  GanacheMineTipset: { namespace: "Ganache" }
};
const instance = new LotusRPC(provider, schema);
instance.ganacheMineTipset(); // calls `Ganache.MineTipset` rpc method instead of `Filecoin.GanacheMineTipset`
instance.chainHead(); // still calls `Filecoin.ChainHead`
```

This PR is still a draft while I ensure it works properly